### PR TITLE
Fix needlessly importing pdfjs which is already pre-imported by React-PDF

### DIFF
--- a/src/components/resume/resume/index.jsx
+++ b/src/components/resume/resume/index.jsx
@@ -5,7 +5,7 @@ import resume from '../../../images/kenneth_bigler_resume.pdf';
 // Parents: Main
 
 // Workaround for worker-loader failing on Webpack 4
-pdfjs.GlobalWorkerOptions.workerSrc = '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.550/pdf.worker.js';
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 export default class Resume extends Component {
   state = {

--- a/src/components/resume/resume/index.jsx
+++ b/src/components/resume/resume/index.jsx
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 // https://github.com/wojtekmaj/react-pdf
-import { Document, Page } from 'react-pdf';
+import { pdfjs, Document, Page } from 'react-pdf';
 import resume from '../../../images/kenneth_bigler_resume.pdf';
 // Parents: Main
 
 // Workaround for worker-loader failing on Webpack 4
-import PdfJsLib from 'pdfjs-dist'; // eslint-disable-line
-PdfJsLib.GlobalWorkerOptions.workerSrc = '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.550/pdf.worker.js';
+pdfjs.GlobalWorkerOptions.workerSrc = '//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.550/pdf.worker.js';
 
 export default class Resume extends Component {
   state = {


### PR DESCRIPTION
Sorry, I didn't notice I already import and provide pdfjs lib from react-pdf. This ensures your code will work fine even if you install a second copy of pdfjs-dist in your repository, which is not the case, but _technically_...